### PR TITLE
the titular ref patch

### DIFF
--- a/frontend/src/components/input_components/SliderInput.vue
+++ b/frontend/src/components/input_components/SliderInput.vue
@@ -1,14 +1,9 @@
 <script setup>
 import Slider from "primevue/slider";
-import { toRef } from "vue";
-const props = defineProps({
-  var: Object,
-});
-// toRef maintains reactivity with the prop var
-// and prop var is from the store
-// so this thing is reactive with the store
+const props = defineProps(['var']);
+// props.var is a ref from the store, so it's already reactive
 // make it so it takes input of unit % nothing years etc
-const slider = toRef(props.var);
+const slider = props.var;
 </script>
 
 <template>


### PR DESCRIPTION
this involves my work on the sliders

`dataStore[variable]` already returns a reactive object (SliderConditions.vue)
- this means that a reactive object was being passed as a prop into SliderInput.vue

`toRef()` on a reactive object does nothing
- SliderInput.vue was using `toRef()` on its prop
- its prop was already reactive
- this was useless

this pr just gets rid of `toRef()`
it still works fine:
![sliders and their matching data from the store below](https://github.com/user-attachments/assets/203ac24e-d5dd-4fda-bba8-e7e2aa347385)